### PR TITLE
Remove most uses of unsafe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["/fixture"]
 bitflags = "2"
 thiserror = "1"
 zerocopy = "0.6"
+arrayvec = "0.7"
 
 [dev-dependencies]
 hex-literal = "0.4"


### PR DESCRIPTION
This adds a `try_from(u8)` implementation for `Register` and `XmmRegister`, and uses an `ArrayVec` for the fixed-capacity epilog buffer. Based mostly on intuition, I am relatively confident that these changes will have no impact on performance.

The only remaining use of unsafe is the test-only mmap unsafe.