### PR TITLE
Fix parsing chained unwind info

### DIFF
--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -743,8 +743,9 @@ impl<'a> UnwindInfo<'a> {
                 handler_data,
             })
         } else if flags.contains(UnwindInfoFlags::CHAININFO) {
+            let (chained, _) = Ref::<_, RuntimeFunction>::new_unaligned_from_prefix(self.rest)?;
             Some(UnwindInfoTrailer::ChainedUnwindInfo {
-                chained: Ref::<_, RuntimeFunction>::new_unaligned(self.rest)?.into_ref(),
+                chained: chained.into_ref(),
             })
         } else {
             None


### PR DESCRIPTION
There is no explicit size information for struct UNWIND_INFO and self.rest does not have a meaningful end pointer. Using new_aligned was causing the size check to fail. Replace this with
new_unaligned_from_prefix.