### PR TITLE
Don't scale offset in ALLOC_LARGE with OpInfo=1

### DIFF
--- a/src/x86_64.rs
+++ b/src/x86_64.rs
@@ -793,7 +793,7 @@ impl<'a> Iterator for UnwindOperations<'a> {
             }
             UnwindOperationCode::AllocLarge => match unwind_code.operation_info() {
                 0 => UnwindOperation::UnStackAlloc(self.read::<U16>()?.get() as u32 * 8),
-                1 => UnwindOperation::UnStackAlloc(self.read::<U32>()?.get() * 8),
+                1 => UnwindOperation::UnStackAlloc(self.read::<U32>()?.get()),
                 _ => return None,
             },
             UnwindOperationCode::AllocSmall => {


### PR DESCRIPTION
Only the 16-bit form is scaled.

Found by inspection. I haven't seen any real apps using the 32-bit form, and this is unlikely to be triggered in practice.